### PR TITLE
fix: use proper link to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to OpenFGA
 
-Please see our main guide here: https://github.com/openfga/.github/blob/update-contribution-guidelines/CONTRIBUTING.md
+Please see our [main guide](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md).
 
 # Testing Guidelines
 


### PR DESCRIPTION
This PR fixes the link to the contribution guidelines and adds a _new line_ symbol at the end of the file.